### PR TITLE
Refactor: extract ID generation and storage logic into separate packages

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1,0 +1,27 @@
+package storage
+
+import "sync"
+
+type MemoryStore struct {
+	data map[string]string
+	mu   sync.RWMutex
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{
+		data: make(map[string]string),
+	}
+}
+
+func (s *MemoryStore) Save(id, url string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.data[id] = url
+}
+
+func (s *MemoryStore) Get(id string) (string, bool) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	url, ok := s.data[id]
+	return url, ok
+}


### PR DESCRIPTION
Moved ID generation logic into a dedicated shortener package.
Centralized short ID generation to ensure reusability and testability.
Laid the groundwork for further modularization (e.g. **persistent storage, tests**).